### PR TITLE
Changed ContainerPort name to follow CNF Cert best-practices.

### DIFF
--- a/controllers/foo_controller.go
+++ b/controllers/foo_controller.go
@@ -105,7 +105,7 @@ func (r *FooReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 						Name:            "jack",
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8080,
-							Name:          "jack",
+							Name:          "http-jack",
 						}},
 						Lifecycle: &corev1.Lifecycle{
 							PostStart: &corev1.LifecycleHandler{


### PR DESCRIPTION
See
https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#manageability-container-port-name-format