### PR TITLE
Automatic container build & publish when new release is created.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Create operator's container image for the new release
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: quay.io
+  TERM: xterm-color
+  OPERATOR_IMAGE_NAME: testnetworkfunction/crd-operator-scaling
+  OPERATOR_IMAGE_TAG: ${{ github.ref_name }}
+
+jobs:
+  publish-new-version:
+    name: Build and publish new version
+    runs-on: ubuntu-22.04
+    env:
+      SHELL: /bin/bash
+
+    steps:
+      - name: Set up Go 1.20
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.5
+
+      - name: Disable default go problem matcher
+        run: echo "::remove-matcher owner=go::"
+
+      - name: Show release tag
+        run: "echo Version: ${{ github.ref_name }}. Full image tag: ${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_TAG}"
+
+      # Clone the operator repo.
+      - name: Check out crd-operator-scaling code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref_name }}
+
+      # Deploy the CRD scaling repo and build it
+      - name: Build operator and make local docker image
+        run: make docker-build IMG=${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_TAG}
+
+      # Push the new operator image to Quay.io.
+      - name: Authenticate against Quay.io
+        if: ${{ github.repository_owner == 'test-network-function' }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          # Use a Robot Account to authenticate against Quay.io
+          # https://docs.quay.io/glossary/robot-accounts.html
+          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Push the newly built official image to Quay.io
+        if: ${{ github.repository_owner == 'test-network-function' }}
+        run: docker push ${REGISTRY}/${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_TAG}


### PR DESCRIPTION
This workflow builds and publish the container belonging to the new release that has just been created.

The creation of the new release will trigger this workflow automatically, and the version tag will be used to tag the final container that will be pushed to quay.io.